### PR TITLE
feat: match victory purple hover (dark) to spec

### DIFF
--- a/src/lib/components/controllers/MagnoliaUIRoot.svelte
+++ b/src/lib/components/controllers/MagnoliaUIRoot.svelte
@@ -121,7 +121,7 @@
 
 	:global(.color-scheme-dark) {
 		--victory-purple: #b59aff;
-		--victory-purple-hover: #8f81b7;
+		--victory-purple-hover: #bbaaf0;
 		--victory-purple-faded: #564b75;
 		--on-victory-purple-faded: #1f1f1f;
 
@@ -146,7 +146,7 @@
 	@media (prefers-color-scheme: dark) {
 		:global(:root) {
 			--victory-purple: #b59aff;
-			--victory-purple-hover: #8f81b7;
+			--victory-purple-hover: #bbaaf0;
 			--victory-purple-faded: #564b75;
 			--on-victory-purple-faded: #1f1f1f;
 


### PR DESCRIPTION
The Magnolia UI Figma doc has changed the hover variant of Victory Purple in dark mode from `#8f81b7` to `#bbaaf0` to match the other hover variants making the color brighter instead of darker. This code change mirrors the design change.